### PR TITLE
Support for `sorts` parsing and generation

### DIFF
--- a/lib/generate/index.js
+++ b/lib/generate/index.js
@@ -101,9 +101,9 @@ function generateLookmlArray(projectFragment,indentation="",strings,precounter="
 			}
 	}
 function isTerminator(str){return str==="}"}
-function isReference(str){return str[0]==="!"}
+function isReference(str){return str[0]==="!" || Array.isArray(str)}
 function isMeta(str){return str[0]==="$"}
-function isReference(stx){return Array.isArray(stx)}
+//function isReference(stx){return Array.isArray(stx)}
 function isPrimitive(val){return typeof val === "string" || typeof val == "boolean" }
 //function isSelfReference(x){return Array.isArray(x) && !x[0]}
 function defaultStrings(val, indentation){
@@ -131,6 +131,9 @@ function  flatPush(tgt, src){
 function flatten(a,b){return a.concat(b)}
 function getReference(obj,path){
 	if(!path){return obj}
+	if(obj.$type == "sorts") {
+		return obj[path]
+	}
 	if(typeof path === "string"){
 		path = path.split(/^!|\./g)
 			.filter(Boolean)

--- a/lib/generate/test.js
+++ b/lib/generate/test.js
@@ -14,6 +14,8 @@ view: foo {
 		# Triggers with my dg
 		datagroup_trigger: my_dg
 		sql: SELECT 1 as id ;;
+		# Wont break on "sorts"
+		sorts: [id: asc, some_field: desc]
 	}
 	dimension: id {} #Comment 2
 }

--- a/lib/parse/lookml.peg
+++ b/lib/parse/lookml.peg
@@ -113,6 +113,21 @@
 		
 		return {$strings, ...collection}
 		}
+	function makeMapList(type, _1, _2, _3, _4, _5, firstKey, firstVal, comma, rest) {
+		var buff = type == "string" ? ['"', [], '"'] : [[]]
+		return {
+			$strings:["[", [`${firstKey}`,..._1,firstKey,..._2,":",..._3, ...buff],
+				...rest.map(   ([   r_1,rcomma,   r_2,rkey,   r_3,rcolon,   r_4, rval])=>
+					[`${rkey}`, ...r_1,rcomma,...r_2,rkey,...r_3,rcolon,...r_4, ...buff]
+					),
+				..._4,comma,..._5,"]"
+				].filter(Boolean),
+			$value: rest.reduce(
+				(obj,[_1,comma,_2,key,_3,colon,_4,value])=>({...obj, [key]:value}),
+				{[firstKey]:firstVal}
+				)
+		}
+	}
 	function isObject(o){return o && typeof o=="object" && !o.push}
 	function flatten(a,b){return a.concat(b)}
 }
@@ -148,7 +163,7 @@ blockDeclaration =
 		$value
 		}}
 arrayDeclaration = 
-	$type:atom _1:_ ":" _2:_ array: (emptyList / atomStarList / stringList / mapList)
+	$type:atom _1:_ ":" _2:_ array: (emptyList / atomStarList / stringList / atomMapList / stringMapList)
 	{return {
 		$strings:[$type, ..._1, ":", ..._2, ...array.$strings].filter(Boolean),
 		$type,
@@ -204,22 +219,17 @@ stringList =
 		$value: [first, ...rest.map(r=>r[3])]
 		}}
 
-mapList = 
+atomMapList =
+	"[" _1:_ firstKey:atom _2:_ ":" _3:_ firstVal:atom rest:(
+		 _ "," _ atom _ ":" _ atom
+		)* _4:_ comma:","? _5:_ "]" 
+		{return makeMapList("atom", _1, _2, _3, _4, _5, firstKey, firstVal, comma, rest)}
+
+stringMapList = 
 	"[" _1:_ firstKey:atom _2:_ ":" _3:_ firstVal:string rest:(
 		 _ "," _ atom _ ":" _ string
 		)* _4:_ comma:","? _5:_ "]" 
-		{return {
-			$strings:["[", [`${firstKey}`,..._1,firstKey,..._2,":",..._3,'"',[],'"'],
-				...rest.map(   ([   r_1,rcomma,   r_2,rkey,   r_3,rcolon,   r_4, rval])=>
-					[`${rkey}`, ...r_1,rcomma,...r_2,rkey,...r_3,rcolon,...r_4,'"',[],'"'  ]
-					),
-				..._4,comma,..._5,"]"
-				].filter(Boolean),
-			$value: rest.reduce(
-				(obj,[_1,comma,_2,key,_3,colon,_4,value])=>({...obj, [key]:value}),
-				{[firstKey]:firstVal}
-				)
-			}}
+		{return makeMapList("string", _1, _2, _3, _4, _5, firstKey, firstVal, comma, rest)}
 
 atom = chars:[-+_a-zA-Z0-9\.]+ {return chars.join('')}
 atomStar = chars:[-+_a-zA-Z0-9\.]+ maybeStar:"*"? {return chars.join('') + (maybeStar||'') }


### PR DESCRIPTION
Nothing huge here but it was getting stuck on `sorts` parameter that can be added to `query` param and NDTs ([example](https://docs.looker.com/reference/explore-params/query)) 

Sorts use "atom" identifiers rather than strings... makes me wonder why we didn't use quotes around "asc" and "desc" 🤷 