### PR TITLE
feat: Allow parseFiles to accept an array of file objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ const lookml = lookmlParser.parse("view: foo{}")
 const positions = lookmlParser.getPositions(lookml)
 
 let project = lookmlParser.parseFiles({
+		// The source parameter can be a glob string, or an array of objects
+		// with path (for matching includes) and content properties
 		source:  "*.{view,model,explore}.lkml",
 		fileOutput: "by-name" // or "array" or "by-type",	
 		globOptions: {},

--- a/lib/parse-files/index.js
+++ b/lib/parse-files/index.js
@@ -27,23 +27,30 @@ exports = module.exports = async function lookmlParser_parseFiles({
 		removeAbstract = true,
 		}={}
 	}={}){
-	const inputFilePaths = await globp(source||defaultSource, {
-		...cwd?{cwd}:{},
-		...globOptions
-		})
 	if(Array.isArray(console)){console = mockConsole(console)}
-	if(!inputFilePaths.length){
-			if(source){console.warn("Warning: No input files were matched for pattern "+source)}
-			else{console.warn("Warning: No input files were matched. (Use argument --input=... or source)")}
-		}
-	const files = await Promise.map(inputFilePaths, async ($file_path,fp)=>{
+	let fileObjects;
+	if(Array.isArray(source)){
+		fileObjects = source.map(s=>({path:s.path, read:()=>Promise.resolve(s.content) }))
+	}else{
+		const inputFilePaths = await globp(source||defaultSource, {
+			...cwd?{cwd}:{},
+			...globOptions
+			})
+		if(!inputFilePaths.length){
+				if(source){console.warn("Warning: No input files were matched for pattern "+source)}
+				else{console.warn("Warning: No input files were matched. (Use argument --input=... or source)")}
+			}
+		fileObjects = inputFilePaths.map($file_path=>({path:$file_path, read:()=>readp(path.resolve(cwd||process.cwd(),$file_path),readFileOptions) }))
+	}
+	const files = await Promise.map(fileObjects, async (fileObject,fp)=>{
+			const $file_path = fileObject.path
 			let typeRegex = /\.?([-_a-zA-Z0-9]+)(\.lkml|\.lookml)?$/i
 			const $file_name = path.basename($file_path).replace(typeRegex,'')
 			const [match,$file_type,$file_supertype] = path.basename($file_path).match(typeRegex)||[]
 			const $file_rel = $file_path.replace(typeRegex,'')
 			var file,result;
 			try{
-				file = await readp(path.resolve(cwd||process.cwd(),$file_path),readFileOptions)
+				file = await fileObject.read()
 				if($file_supertype == '.lookml'){
 					result = maybeYamlParser.parse(file)
 					if($file_type==="dashboard"){

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     }
   },
   "devDependencies": {
-    "test-runner": "^0.5.0"
+    "test-runner": "^0.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lookml-parser",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "Parse LookML",
   "main": "index.js",
   "scripts": {

--- a/test-projects/023-array-of-files/test.json
+++ b/test-projects/023-array-of-files/test.json
@@ -1,0 +1,66 @@
+{
+	"parseFileOptions":{
+			"fileOutput":"by-name",
+			"source": [
+				{
+					"path": "simple.model.lkml",
+					"content": "include: \"facts.view.lkml\" explore: facts {}"
+				},
+				{
+					"path": "facts.view.lkml",
+					"content": "view: facts { sql_table_name: my_schema.facts ;; }"
+				}
+			]
+	},
+	"expected":{
+		"file": {
+			"simple.model": {
+				"include": "facts.view.lkml",
+				"explore": {
+					"facts": {
+						"$type": "explore",
+						"$name": "facts"
+					}
+				},
+				"$file_path": "simple.model.lkml",
+				"$file_rel": "simple",
+				"$file_name": "simple",
+				"$file_type": "model"
+			},
+			"facts.view": {
+				"view": {
+					"facts": {
+						"$type": "view",
+						"$name": "facts",
+						"sql_table_name": " my_schema.facts "
+					}
+				},
+				"$file_path": "facts.view.lkml",
+				"$file_rel": "facts",
+				"$file_name": "facts",
+				"$file_type": "view"
+			}
+		},
+		"model": {
+			"simple": {
+				"$type": "model",
+				"$name": "simple",
+				"include": "facts.view.lkml",
+				"explore": {
+					"facts": {
+						"$type": "explore",
+						"$name": "facts"
+						}
+					},
+				"view": {
+					"facts": {
+						"$type": "view",
+						"$name": "facts",
+						"sql_table_name": " my_schema.facts "
+						}
+					}
+				}
+			}
+		}
+
+	}


### PR DESCRIPTION
This change allows the `parseFiles` function to accept an array of file objects as the `source` argument, in addition to the existing glob string. This is useful for users who want to parse files that are already in memory, without having to write them to disk first.

The file objects in the array should have the following properties:

- `path`: The path to the file, which is used for matching includes.
- `content`: The content of the file as a string.
